### PR TITLE
docs(readme): fix namespace references

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ dotnet add package QRCoder.Core
 Generate your first QR code with just a few lines of code:
 
 ```csharp
-using QRCoder.Core;
-using SkiaSharp;
+using QRCoder.Core.Generators;
+using QRCoder.Core.Renderers;
 
 // Create the QR Code generator
 using var generator = new QRCodeGenerator();
@@ -163,7 +163,7 @@ string psString = ps.GetGraphic(5);
 ### Payload Examples
 
 ```csharp
-using QRCoder.Core;
+using QRCoder.Core.Generators;
 
 // Wi-Fi QR Code
 var wifiPayload = new PayloadGenerator.WiFi("MyNetwork", "MyPassword",


### PR DESCRIPTION
Update using statements in code examples to use the correct namespaces
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/afonsoft/qrcoder.core/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->